### PR TITLE
Add id_col to osrmTable

### DIFF
--- a/R/osrmTable.R
+++ b/R/osrmTable.R
@@ -1,11 +1,11 @@
 #' @name osrmTable
 #' @title Get Travel Time Matrices Between Points
-#' @description Build and send OSRM API queries to get travel time matrices 
-#' between points. This function interfaces the \emph{table} OSRM service.\cr 
+#' @description Build and send OSRM API queries to get travel time matrices
+#' between points. This function interfaces the \emph{table} OSRM service.\cr
 #' Use \code{src} and \code{dst} to set different origins and destinations.\cr
-#' Use \code{loc} to compute travel times or travel distances between all 
-#' points. 
-#' @param src origin points. 
+#' Use \code{loc} to compute travel times or travel distances between all
+#' points.
+#' @param src origin points.
 #' \code{src} can be: \itemize{
 #'   \item a data.frame of longitudes and latitudes (WGS 84),
 #'   \item a matrix of longitudes and latitudes (WGS 84),
@@ -13,7 +13,7 @@
 #'   \item an sf object of type POINT.
 #'}
 #' If relevant, row names are used as identifiers.
-#' @param dst destination. 
+#' @param dst destination.
 #' \code{dst} can be: \itemize{
 #'   \item a data.frame of longitudes and latitudes (WGS 84),
 #'   \item a matrix of longitudes and latitudes (WGS 84),
@@ -28,16 +28,17 @@
 #'   \item an sf object of type POINT.
 #'}
 #' If relevant, row names are used as identifiers.
-#' @param measure a character indicating what measures are calculated. It can 
+#' @param measure a character indicating what measures are calculated. It can
 #' be "duration" (in minutes), "distance" (meters), or both c('duration',
-#' 'distance').  
+#' 'distance').
 #' @param exclude pass an optional "exclude" request option to the OSRM API
 #' (not allowed with the OSRM demo server).
+#' @param id_col a character indicating the identifer column that will be used to return the results. Defaults to row names.
 #' @param osrm.server the base URL of the routing server.
 #' @param osrm.profile the routing profile to use, e.g. "car", "bike" or "foot".
 #' @return
-#' The output of this function is a list composed of one or two matrices 
-#' and 2 data.frames 
+#' The output of this function is a list composed of one or two matrices
+#' and 2 data.frames
 #' \itemize{
 #'   \item{durations}: a matrix of travel times (in minutes)
 #'   \item{distances}: a matrix of distances (in meters)
@@ -46,11 +47,11 @@
 #'   \item{sources}: a data.frame of the coordinates of the points actually
 #'   used as destinations (EPSG:4326 - WGS84)
 #'   }
-#' @note 
-#' The OSRM demo server does not allow large queries (more than 10000 distances 
+#' @note
+#' The OSRM demo server does not allow large queries (more than 10000 distances
 #' or durations).\cr
 #' If you use your own server and if you want to get a large number of distances
-#' make sure to set the "max-table-size" option (Max. locations supported in 
+#' make sure to set the "max-table-size" option (Max. locations supported in
 #' table) of the OSRM server accordingly.
 #' @examples
 #' \dontrun{
@@ -60,72 +61,77 @@
 #' distA <- osrmTable(loc = apotheke.df[1:50, c("lon","lat")])
 #' # First 5 rows and columns
 #' distA$durations[1:5,1:5]
-#' 
+#'
 #' # Travel time matrix with different sets of origins and destinations
 #' distA2 <- osrmTable(src = apotheke.df[1:10,c("lon","lat")],
 #'                     dst = apotheke.df[11:20,c("lon","lat")])
 #' # First 5 rows and columns
 #' distA2$durations[1:5,1:5]
-#' 
+#'
 #' # Inputs are sf points
 #' library(sf)
-#' apotheke.sf <- st_read(system.file("gpkg/apotheke.gpkg", package = "osrm"), 
+#' apotheke.sf <- st_read(system.file("gpkg/apotheke.gpkg", package = "osrm"),
 #'                        quiet = TRUE)
 #' distA3 <- osrmTable(loc = apotheke.sf[1:10,])
 #' # First 5 rows and columns
 #' distA3$durations[1:5,1:5]
-#' 
+#'
 #' # Travel time matrix with different sets of origins and destinations
 #' distA4 <- osrmTable(src = apotheke.sf[1:10,], dst = apotheke.sf[11:20,])
 #' # First 5 rows and columns
 #' distA4$durations[1:5,1:5]
-#' 
+#'
 #' # Road distance matrix with different sets of origins and destinations
-#' distA5 <- osrmTable(src = apotheke.sf[1:10,], dst = apotheke.sf[11:20,], 
+#' distA5 <- osrmTable(src = apotheke.sf[1:10,], dst = apotheke.sf[11:20,],
 #'                     measure = "distance")
 #' # First 5 rows and columns
 #' distA5$distances[1:5,1:5]
 #' }
 #' @export
-osrmTable <- function(src, 
-                      dst = src, 
-                      loc, 
-                      exclude, 
-                      measure = "duration", 
+osrmTable <- function(src,
+                      dst = src,
+                      loc,
+                      exclude,
+                      id_col,
+                      measure = "duration",
                       osrm.server = getOption("osrm.server"),
                       osrm.profile = getOption("osrm.profile")){
-  
+
   opt <- options(error = NULL)
   on.exit(options(opt), add=TRUE)
-  
+
   url <- base_url(osrm.server, osrm.profile, "table")
-  
+
+  if(missing(id_col)) {
+
+  }
+
   # input management
   if(!missing(loc)){
-    loc <- input_table(x = loc, id = 'loc')
+    loc <- input_table(x = loc, id = 'loc', id_col = id_col)
     dst_r <- src_r <- loc
     url <- paste0(url, encode_coords(x = loc), "?")
   }else{
-    src_r <- input_table(x = src, id = 'src')
-    dst_r <- input_table(x = dst, id = 'dst')
+    src_r <- input_table(x = src, id = 'src', id_col = id_col)
+    dst_r <- input_table(x = dst, id = 'dst', id_col = id_col)
     loc <- rbind(src_r, dst_r)
-    url <- paste0(url, 
-                  encode_coords(x = loc), 
-                  paste0("?sources=", 
-                         paste(0:(nrow(src_r)-1), collapse = ";"), 
-                         "&destinations=", 
+    url <- paste0(url,
+                  encode_coords(x = loc),
+                  paste0("?sources=",
+                         paste(0:(nrow(src_r)-1), collapse = ";"),
+                         "&destinations=",
                          paste(nrow(src_r):(nrow(loc)-1), collapse = ";")),
                   "&")
   }
-  
+
   # adding exclude parameter
   if (!missing(exclude)) {
     url <- paste0(url, "exclude=", exclude, "&")
   }
   # adding measure parameter
-  url <- paste0(url, 
-                "annotations=", 
-                paste0(measure, collapse=','), 
+  url <- paste0(url,
+                "annotations=",
+                paste0(measure, collapse=','),
                 "&generate_hints=false")
   # print(url)
   e <- try({
@@ -136,27 +142,27 @@ osrmTable <- function(src,
   if (inherits(e,"try-error")){
     stop(e, call. = FALSE)
   }
-  
+
   # test result validity
   test_http_error(r)
-  
+
   res <- RcppSimdJson::fparse(rawToChar(r$content))
-  
+
   # create dummy dataset for tests
   # return(list(res = res, src = src_r, dst = dst_r))
-  
+
   # format results
   output <- list()
   if(!is.null(res$durations)){
-    output$durations <- tab_format(res = res, 
-                                   src = src_r, 
-                                   dst = dst_r, 
+    output$durations <- tab_format(res = res,
+                                   src = src_r,
+                                   dst = dst_r,
                                    type = "duration")
   }
   if(!is.null(res$distances)){
-    output$distances <- tab_format(res = res, 
-                                   src = src_r, 
-                                   dst = dst_r, 
+    output$distances <- tab_format(res = res,
+                                   src = src_r,
+                                   dst = dst_r,
                                    type = "distance")
   }
   # get the coordinates

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,70 +33,75 @@ tab_format <- function(res, src, dst, type){
   # col and row names management
   dimnames(mat) <- list(src$id, dst$id)
   return(mat)
-}  
+}
 
 
 coord_format <- function(res, src, dst){
-  sources <- data.frame(matrix(unlist(res$sources$location, 
-                                      use.names = T), 
-                               ncol = 2, byrow = T, 
+  sources <- data.frame(matrix(unlist(res$sources$location,
+                                      use.names = T),
+                               ncol = 2, byrow = T,
                                dimnames = list(src$id, c("lon", "lat"))))
-  destinations <- data.frame(matrix(unlist(res$destinations$location, 
-                                           use.names = T), 
-                                    ncol = 2, byrow = T, 
+  destinations <- data.frame(matrix(unlist(res$destinations$location,
+                                           use.names = T),
+                                    ncol = 2, byrow = T,
                                     dimnames = list(dst$id, c("lon", "lat"))))
   return(list(sources = sources, destinations = destinations)
   )
 }
 
-input_table <- function(x, id){
+input_table <- function(x, id, id_col){
   if (inherits(x = x, what = c("sfc", "sf"))) {
     lx <- length(st_geometry(x))
     if (lx < 1){
-      stop(paste0('"', id, '" should have at least 1 row or element.'), 
+      stop(paste0('"', id, '" should have at least 1 row or element.'),
            call. = FALSE)
     }
     type <- sf::st_geometry_type(x, by_geometry = TRUE)
     type <- as.character(unique(type))
     if (length(type) > 1 || type != "POINT") {
-      stop(paste0('"', id, '" geometry should be of type POINT.'), 
+      stop(paste0('"', id, '" geometry should be of type POINT.'),
            call. = FALSE)    }
     if(inherits(x, "sfc")){
       idx <- 1:lx
     }else{
-      idx <- row.names(x)
+      if(missing(id_col)) {
+        idx <- row.names(x)
+      } else {
+        idx <- x |> dplyr::as_tibble() |> select(!!!rlang::syms(id_col)) |> pull()
+      }
+
     }
     x <- sf::st_transform(x = x, crs = 4326)
     coords <- sf::st_coordinates(x)
-    x <- data.frame(id = idx, 
-                    lon = clean_coord(coords[,1]), 
+    x <- data.frame(id = idx,
+                    lon = clean_coord(coords[,1]),
                     lat = clean_coord(coords[,2]))
     return(x)
   }
   if(inherits(x = x, what = c("data.frame", "matrix"))){
     lx <- nrow(x)
     if(lx < 1){
-      stop(paste0('"', id, '" should have at least 1 row or element.'), 
+      stop(paste0('"', id, '" should have at least 1 row or element.'),
            call. = FALSE)
     }
     if(ncol(x) == 2 && is.numeric(x[,1]) && is.numeric(x[,2])){
-      
+
       rn <- row.names(x)
       if(is.null(rn)){rn <- 1:lx}
-      
-      x <- data.frame(id = rn, 
-                      lon = clean_coord(x[,1]), 
+
+      x <- data.frame(id = rn,
+                      lon = clean_coord(x[,1]),
                       lat = clean_coord(x[,2]))
       return(x)
     }else{
-      stop(paste0('"', id, '" should contain coordinates.'), 
+      stop(paste0('"', id, '" should contain coordinates.'),
            call. = FALSE)
     }
   }else{
-    stop(paste0('"', id, '" should be ', 
-                'a data.frame or a matrix ', 
-                'of coordinates, an sfc POINT object or an ', 
-                'sf POINT object.'), 
+    stop(paste0('"', id, '" should be ',
+                'a data.frame or a matrix ',
+                'of coordinates, an sfc POINT object or an ',
+                'sf POINT object.'),
          call. = FALSE)
   }
 }
@@ -115,11 +120,11 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
                call. = FALSE)
         }
         lon <- clean_coord(x[1])
-        lat <- clean_coord(x[2])  
+        lat <- clean_coord(x[2])
         return(list(id = id, lon = lon, lat = lat, oprj = oprj))
       }else{
-        stop(paste0('"', id, '" should be a numeric vector of length 2, ', 
-                    'i.e., c(lon, lat).'), 
+        stop(paste0('"', id, '" should be a numeric vector of length 2, ',
+                    'i.e., c(lon, lat).'),
              call. = FALSE)
       }
     }
@@ -136,7 +141,7 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
         idx <- row.names(x)
       }
       if(sf::st_geometry_type(x, by_geometry = FALSE) != "POINT"){
-        stop(paste0('"', id, '" geometry should be of type POINT.'), 
+        stop(paste0('"', id, '" geometry should be of type POINT.'),
              call. = FALSE)
       }
       x <- sf::st_transform(x = x, crs = 4326)
@@ -155,17 +160,17 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
       x <- unlist(x)
       if(length(x) == 2 & is.numeric(x)){
         lon <- clean_coord(x[1])
-        lat <- clean_coord(x[2])  
+        lat <- clean_coord(x[2])
         return(list(id = idx, lon = lon, lat = lat, oprj = oprj))
       }else{
-        stop(paste0('"', id, '" should contain coordinates.'), 
+        stop(paste0('"', id, '" should contain coordinates.'),
              call. = FALSE)
       }
     }else{
-      stop(paste0('"', id, '" should be a vector of coordinates, ', 
-                  'a data.frame or a matrix ', 
-                  'of coordinates, an sfc POINT object or an ', 
-                  'sf POINT object.'), 
+      stop(paste0('"', id, '" should be a vector of coordinates, ',
+                  'a data.frame or a matrix ',
+                  'of coordinates, an sfc POINT object or an ',
+                  'sf POINT object.'),
            call. = FALSE)
     }
   }else{
@@ -173,7 +178,7 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
       oprj <- st_crs(x)
       lx <- length(st_geometry(x))
       if (lx < 2){
-        stop('"loc" should have at least 2 rows or elements.', 
+        stop('"loc" should have at least 2 rows or elements.',
              call. = FALSE)
       }
       type <- sf::st_geometry_type(x, by_geometry = FALSE)
@@ -218,14 +223,14 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
           return(list(id = rn, lon = lon, lat = lat, oprj = oprj))
         }
       }else{
-        stop(paste0('"loc" should contain coordinates.'), 
+        stop(paste0('"loc" should contain coordinates.'),
              call. = FALSE)
       }
     }else{
-      stop(paste0('"loc" should be ', 
-                  'a data.frame or a matrix ', 
-                  'of coordinates, an sfc POINT object or an ', 
-                  'sf POINT object.'), 
+      stop(paste0('"loc" should be ',
+                  'a data.frame or a matrix ',
+                  'of coordinates, an sfc POINT object or an ',
+                  'sf POINT object.'),
            call. = FALSE)
     }
   }
@@ -240,7 +245,7 @@ input_route <- function(x, id, single = TRUE, all.ids = FALSE){
 # construct the base url
 base_url <- function(osrm.server, osrm.profile, query){
   if(osrm.server == "https://routing.openstreetmap.de/") {
-    url <- paste0(osrm.server, "routed-", osrm.profile, "/", 
+    url <- paste0(osrm.server, "routed-", osrm.profile, "/",
                   query, "/v1/driving/")
   }else{
     url <- paste0(osrm.server, query, "/v1/", osrm.profile, "/")
@@ -250,7 +255,7 @@ base_url <- function(osrm.server, osrm.profile, query){
 
 # create short and clean coordinates
 clean_coord <- function(x){
-  format(round(as.numeric(x),5), scientific = FALSE, justify = "none", 
+  format(round(as.numeric(x),5), scientific = FALSE, justify = "none",
          trim = TRUE, nsmall = 5, digits = 5)
 }
 
@@ -268,16 +273,16 @@ test_http_error <- function(r){
     if (substr(r$type, 1, 16) != "application/json") {
       stop(
         sprintf(
-          "OSRM API request failed [%s]", 
+          "OSRM API request failed [%s]",
           r$status_code),
         call. = FALSE)
     }else{
       rep <- RcppSimdJson::fparse(rawToChar(r$content))
       stop(
         sprintf(
-          "OSRM API request failed [%s]\n%s\n%s", 
-          r$status_code, 
-          rep$code, 
+          "OSRM API request failed [%s]\n%s\n%s",
+          r$status_code,
+          rep$code,
           rep$message
         ),
         call. = FALSE
@@ -292,8 +297,8 @@ fill_grid <- function(destinations, measure, sgrid, res, tmax){
   rpt <- st_transform(rpt, 3857)
   rpt$measure <- measure
   b <- as.numeric(st_distance(sgrid[1,], sgrid[2,]) / 2)
-  xx <- st_make_grid(x = st_buffer(x = st_as_sfc(st_bbox(sgrid)), 
-                                   dist = b), 
+  xx <- st_make_grid(x = st_buffer(x = st_as_sfc(st_bbox(sgrid)),
+                                   dist = b),
                      n = c(res, res))
   ag_pt <- function(x){
     if (length(x > 0)){


### PR DESCRIPTION
Enables the user to specify a column that is used to return the results by for easier understanding. Defaults to previous behaviour of using the row names.